### PR TITLE
fix: correctness bugs in result containers, preprocessing and postprocessing

### DIFF
--- a/src/model/zip.rs
+++ b/src/model/zip.rs
@@ -51,7 +51,7 @@ struct EndOfCentralDirectoryRecord<'buf> {
 
 impl<'buf> EndOfCentralDirectoryRecord<'buf> {
     const HEAD_SIGNATURE: &'static [u8] = &[0x50, 0x4b, 0x05, 0x06];
-    const MIN_SIZE: usize = 20; // at least 20 bytes
+    const MIN_SIZE: usize = 22;
 
     const NUMBER_OF_THIS_DISK_POS: usize = 4;
     const DISK_WHERE_CENTRAL_DIRECTORY_STARTS_POS: usize = 6;
@@ -608,6 +608,10 @@ mod test {
     #[test]
     fn test_end_of_central_directory_record() {
         assert!(EndOfCentralDirectoryRecord::new(&[]).is_err());
+
+        let mut truncated = vec![0u8; 23];
+        truncated[2..6].copy_from_slice(EndOfCentralDirectoryRecord::HEAD_SIGNATURE);
+        assert!(EndOfCentralDirectoryRecord::new(&truncated).is_err());
 
         let buf = std::fs::read(ZIP_PATH).unwrap();
         let r = EndOfCentralDirectoryRecord::new(buf.as_slice()).unwrap();

--- a/src/postprocess/containers/common/category.rs
+++ b/src/postprocess/containers/common/category.rs
@@ -46,18 +46,57 @@ impl Eq for Category {}
 
 impl PartialEq<Self> for Category {
     fn eq(&self, other: &Self) -> bool {
-        self.index.eq(&other.index)
+        self.cmp(other) == Ordering::Equal
     }
 }
 
 impl PartialOrd<Self> for Category {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        other.score.partial_cmp(&self.score)
+        Some(self.cmp(other))
     }
 }
 
+/// Orders by descending score, then by ascending index.
 impl Ord for Category {
     fn cmp(&self, other: &Self) -> Ordering {
-        other.score.partial_cmp(&self.score).unwrap()
+        other
+            .score
+            .total_cmp(&self.score)
+            .then_with(|| self.index.cmp(&other.index))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn category(index: u32, score: f32) -> Category {
+        Category {
+            index,
+            score,
+            category_name: None,
+            display_name: None,
+        }
+    }
+
+    #[test]
+    fn test_category_order() {
+        let mut categories = vec![
+            category(0, 0.1),
+            category(1, f32::NAN),
+            category(2, 0.9),
+            category(3, 0.1),
+        ];
+        categories.sort();
+        let indices: Vec<u32> = categories.iter().map(|c| c.index).collect();
+        assert_eq!(indices, [1, 2, 0, 3]);
+
+        assert_eq!(category(0, 0.5), category(0, 0.5));
+        assert_ne!(category(0, 0.5), category(0, 0.6));
+        assert_ne!(category(0, 0.5), category(1, 0.5));
+        assert_eq!(
+            category(0, 0.5).partial_cmp(&category(1, 0.5)),
+            Some(Ordering::Less)
+        );
     }
 }

--- a/src/postprocess/containers/common/results_iter_impl.rs
+++ b/src/postprocess/containers/common/results_iter_impl.rs
@@ -1,14 +1,5 @@
 macro_rules! results_iter_impl {
     () => {
-        /// poll all results
-        #[inline(always)]
-        pub fn collect<B: FromIterator<TaskSession::Result>>(self) -> B
-        where
-            Self: Sized,
-        {
-            todo!()
-        }
-
         /// poll all results and save to [`Vec`]
         #[inline(always)]
         pub fn to_vec(mut self) -> Result<Vec<TaskSession::Result>, crate::Error> {

--- a/src/postprocess/containers/vision/landmark.rs
+++ b/src/postprocess/containers/vision/landmark.rs
@@ -51,7 +51,7 @@ impl IntoIterator for Landmarks {
 
     #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
-        todo!()
+        self.0.into_iter()
     }
 }
 
@@ -65,13 +65,12 @@ impl Landmark {
     pub const LANDMARK_TOLERANCE: f32 = 1e-6;
 }
 
-impl Eq for Landmark {}
-
+/// Approximate equality on x, y, z within [`Landmark::LANDMARK_TOLERANCE`].
 impl PartialEq for Landmark {
     fn eq(&self, other: &Self) -> bool {
-        return (self.x - other.x).abs() < Self::LANDMARK_TOLERANCE
-            && (self.y - other.y) < Self::LANDMARK_TOLERANCE
-            && (self.z - other.z) < Self::LANDMARK_TOLERANCE;
+        (self.x - other.x).abs() < Self::LANDMARK_TOLERANCE
+            && (self.y - other.y).abs() < Self::LANDMARK_TOLERANCE
+            && (self.z - other.z).abs() < Self::LANDMARK_TOLERANCE
     }
 }
 
@@ -148,5 +147,40 @@ pub(crate) fn projection_world_landmark(
             l.x = x;
             l.y = y;
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn landmark(x: f32, y: f32, z: f32) -> Landmark {
+        Landmark {
+            x,
+            y,
+            z,
+            visibility: None,
+            presence: None,
+            name: None,
+        }
+    }
+
+    #[test]
+    fn test_landmark_eq_is_symmetric() {
+        let a = landmark(0.0, 0.0, 0.0);
+        let b = landmark(0.0, 1.0, 0.0);
+        let c = landmark(0.0, 0.0, 1.0);
+        assert_ne!(a, b);
+        assert_ne!(b, a);
+        assert_ne!(a, c);
+        assert_ne!(c, a);
+        assert_eq!(a, landmark(0.0, 1e-7, -1e-7));
+    }
+
+    #[test]
+    fn test_landmarks_into_iter() {
+        let landmarks = Landmarks(vec![landmark(1.0, 2.0, 3.0), landmark(4.0, 5.0, 6.0)]);
+        let xs: Vec<f32> = landmarks.into_iter().map(|l| l.x).collect();
+        assert_eq!(xs, [1.0, 4.0]);
     }
 }

--- a/src/postprocess/containers/vision/landmark.rs
+++ b/src/postprocess/containers/vision/landmark.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 /// Landmark represents a point in 3D space with x, y, z coordinates. The
 /// landmark coordinates are in meters. z represents the landmark depth, and the
 /// smaller the value the closer the world landmark is to the camera.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Landmark {
     pub x: f32,
     pub y: f32,
@@ -63,11 +63,9 @@ pub type NormalizedLandmarks = Landmarks;
 
 impl Landmark {
     pub const LANDMARK_TOLERANCE: f32 = 1e-6;
-}
 
-/// Approximate equality on x, y, z within [`Landmark::LANDMARK_TOLERANCE`].
-impl PartialEq for Landmark {
-    fn eq(&self, other: &Self) -> bool {
+    /// Compare x, y and z within [`Landmark::LANDMARK_TOLERANCE`].
+    pub fn approx_eq(&self, other: &Self) -> bool {
         (self.x - other.x).abs() < Self::LANDMARK_TOLERANCE
             && (self.y - other.y).abs() < Self::LANDMARK_TOLERANCE
             && (self.z - other.z).abs() < Self::LANDMARK_TOLERANCE
@@ -166,15 +164,17 @@ mod test {
     }
 
     #[test]
-    fn test_landmark_eq_is_symmetric() {
+    fn test_landmark_approx_eq_is_symmetric() {
         let a = landmark(0.0, 0.0, 0.0);
         let b = landmark(0.0, 1.0, 0.0);
         let c = landmark(0.0, 0.0, 1.0);
-        assert_ne!(a, b);
-        assert_ne!(b, a);
-        assert_ne!(a, c);
-        assert_ne!(c, a);
-        assert_eq!(a, landmark(0.0, 1e-7, -1e-7));
+        assert!(!a.approx_eq(&b));
+        assert!(!b.approx_eq(&a));
+        assert!(!a.approx_eq(&c));
+        assert!(!c.approx_eq(&a));
+        assert!(a.approx_eq(&landmark(0.0, 1e-7, -1e-7)));
+        assert_ne!(a, landmark(0.0, 1e-7, -1e-7));
+        assert_eq!(a, landmark(0.0, 0.0, 0.0));
     }
 
     #[test]

--- a/src/postprocess/processing/common/tensors_to_embedding.rs
+++ b/src/postprocess/processing/common/tensors_to_embedding.rs
@@ -54,18 +54,13 @@ impl TensorsToEmbedding {
             if self.quantize {
                 float_embedding = Vec::new();
                 quantized_embedding = Vec::with_capacity(tensor.len());
-                if self.l2_normalize {
-                    let inv_l2_norm = Self::get_inverse_l2_norm(tensor);
-                    for t in tensor {
-                        let value = (*t) * inv_l2_norm;
-                        let i = (value * 128.).round() as i32;
-                        quantized_embedding.push(std::cmp::max(-128, std::cmp::min(i, 127) as i8));
-                    }
+                let scale = if self.l2_normalize {
+                    Self::get_inverse_l2_norm(tensor)
                 } else {
-                    for t in tensor {
-                        let i = ((*t) * 128.).round() as i32;
-                        quantized_embedding.push(std::cmp::max(-128, std::cmp::min(i, 127) as i8));
-                    }
+                    1.0
+                };
+                for t in tensor {
+                    quantized_embedding.push(Self::quantize_value((*t) * scale));
                 }
             } else {
                 quantized_embedding = Vec::new();
@@ -94,6 +89,12 @@ impl TensorsToEmbedding {
         }
     }
 
+    /// Scales by 128 and saturates to the i8 range before narrowing.
+    #[inline(always)]
+    fn quantize_value(value: f32) -> i8 {
+        ((value * 128.).round() as i32).clamp(-128, 127) as i8
+    }
+
     /// Computes the inverse L2 norm of the provided array of values. Returns 1.0 in case all values are 0.
     fn get_inverse_l2_norm(values: &[f32]) -> f32 {
         let mut squared_l2_norm = 0.0;
@@ -107,5 +108,20 @@ impl TensorsToEmbedding {
             inv_l2_norm = 1.0 / squared_l2_norm.sqrt();
         }
         return inv_l2_norm;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::TensorsToEmbedding;
+
+    #[test]
+    fn test_quantize_value_saturates() {
+        assert_eq!(TensorsToEmbedding::quantize_value(0.5), 64);
+        assert_eq!(TensorsToEmbedding::quantize_value(-0.5), -64);
+        assert_eq!(TensorsToEmbedding::quantize_value(1.0), 127);
+        assert_eq!(TensorsToEmbedding::quantize_value(-1.0), -128);
+        assert_eq!(TensorsToEmbedding::quantize_value(3.0), 127);
+        assert_eq!(TensorsToEmbedding::quantize_value(-3.0), -128);
     }
 }

--- a/src/postprocess/processing/vision/tensors_to_detection.rs
+++ b/src/postprocess/processing/vision/tensors_to_detection.rs
@@ -292,7 +292,7 @@ impl<'a> TensorsToDetection<'a> {
         if let Some(ref mut c) = self.categories_buf {
             realloc_output_buffer!(c, num_boxes);
         }
-        realloc_output_buffer!(self.location_buf, num_boxes * num_boxes);
+        realloc_output_buffer!(self.location_buf, num_boxes * self.options.num_coords);
     }
 
     pub(crate) fn result(&mut self, num_boxes: usize) -> DetectionResult {

--- a/src/preprocess/audio/audio_data_to_tensor.rs
+++ b/src/preprocess/audio/audio_data_to_tensor.rs
@@ -97,21 +97,21 @@ impl<'a, Source: AudioData> AudioDataToTensorIter<'a, Source> {
         }
 
         let mono_output = self.audio_to_tensor_info.num_channels == 1;
-        let channels_match = num_channels != self.audio_to_tensor_info.num_channels as usize;
-        if !mono_output && !channels_match {
+        let channels_mismatch = num_channels != self.audio_to_tensor_info.num_channels;
+        if channels_mismatch && !mono_output {
             return Err(Error::ArgumentError(format!(
                 "Audio input has `{}` channel(s) but the model requires `{}` channel(s)",
                 num_channels, self.audio_to_tensor_info.num_channels
             )));
         }
 
-        if !channels_match {
-            // cal the mean
+        if channels_mismatch {
+            // downmix to mono: average all channels into channel 0
             let (mean, buffers) = self.input_buffer.as_mut_slice().split_at_mut(1);
-            let mean = mean[0].as_mut_slice();
+            let mean = &mut mean[0][..num_samples];
             for samples in buffers {
-                for j in 0..samples.len() {
-                    mean[j] += samples[j];
+                for (m, s) in mean.iter_mut().zip(&samples[..num_samples]) {
+                    *m += *s;
                 }
             }
             let div = num_channels as f32;
@@ -177,5 +177,48 @@ impl<'a, Source: AudioData> AudioDataToTensorIter<'a, Source> {
             }
             _ => unreachable!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn info(num_channels: usize) -> AudioToTensorInfo {
+        AudioToTensorInfo {
+            num_channels,
+            num_samples: 4,
+            sample_rate: 4,
+            num_overlapping_samples: 0,
+            tensor_type: TensorType::F32,
+        }
+    }
+
+    fn poll(info: &AudioToTensorInfo, channels: Vec<Vec<f32>>) -> Result<Vec<f32>, Error> {
+        let data = AudioRawData::new(channels, 4)?;
+        let mut iter = AudioDataToTensorIter::new(info, data)?;
+        let mut buffers = [vec![0u8; info.num_channels * info.num_samples * 4]];
+        iter.poll_next_tensors(&mut buffers)?;
+        Ok(buffers[0]
+            .chunks_exact(4)
+            .map(|b| f32::from_ne_bytes(b.try_into().unwrap()))
+            .collect())
+    }
+
+    #[test]
+    fn test_stereo_input_downmixes_to_mono_model() {
+        let out = poll(&info(1), vec![vec![1., 1., 1., 1.], vec![3., 3., 3., 3.]]).unwrap();
+        assert_eq!(out, [2., 2., 2., 2.]);
+    }
+
+    #[test]
+    fn test_matching_channels_pass_through() {
+        let out = poll(&info(2), vec![vec![1., 1., 1., 1.], vec![3., 3., 3., 3.]]).unwrap();
+        assert_eq!(out, [1., 1., 1., 1., 3., 3., 3., 3.]);
+    }
+
+    #[test]
+    fn test_channel_mismatch_for_multichannel_model_is_error() {
+        assert!(poll(&info(2), vec![vec![1., 1., 1., 1.]]).is_err());
     }
 }

--- a/src/preprocess/vision/image.rs
+++ b/src/preprocess/vision/image.rs
@@ -7,16 +7,19 @@ pub(super) use image_crate::{
 
 const IMAGE_RESIZE_FILTER: imageops::FilterType = imageops::FilterType::Gaussian;
 
-macro_rules! get_rgb_mean_std_from_info {
-    ( $info:ident ) => {{
-        let r_mean = $info.normalization_options.0.get(0).unwrap();
-        let r_std = $info.normalization_options.1.get(0).unwrap();
-        let g_mean = $info.normalization_options.0.get(1).unwrap_or(r_mean);
-        let g_std = $info.normalization_options.1.get(1).unwrap_or(r_std);
-        let b_mean = $info.normalization_options.0.get(1).unwrap_or(r_mean);
-        let b_std = $info.normalization_options.1.get(1).unwrap_or(r_std);
-        (r_mean, r_std, g_mean, g_std, b_mean, b_std)
-    }};
+/// Returns per-channel (mean, std) for RGB. Channels absent from the metadata reuse the first value.
+fn rgb_mean_std(info: &ImageToTensorInfo) -> Result<([f32; 3], [f32; 3]), Error> {
+    let (mean, std) = (&info.normalization_options.0, &info.normalization_options.1);
+    let (Some(&mean0), Some(&std0)) = (mean.first(), std.first()) else {
+        return Err(Error::ModelInconsistentError(
+            "Float32 image input requires NormalizationOptions (mean/std) in model metadata".into(),
+        ));
+    };
+    let pick = |v: &[f32], i: usize, default: f32| v.get(i).copied().unwrap_or(default);
+    Ok((
+        [mean0, pick(mean, 1, mean0), pick(mean, 2, mean0)],
+        [std0, pick(std, 1, std0), pick(std, 2, std0)],
+    ))
 }
 
 impl ImageToTensor for DynamicImage {
@@ -129,72 +132,59 @@ where
             && info.color_space != ImageColorSpaceType::GRAYSCALE
     );
 
-    info.normalization_options.0.get(0).unwrap_or(&1f32);
-
     let data_layout = info.image_data_layout;
     let res = output_buffer.as_mut();
-    let mut res_index = 0;
+    let bytes = img.as_bytes();
+    let hw = (img.width() * img.height()) as usize;
+    let expected_len = bytes.len() * tensor_byte_size!(info.tensor_type);
+    if res.len() < expected_len {
+        return Err(Error::ArgumentError(format!(
+            "Expect output buffer at least `{}` bytes, but got `{}`",
+            expected_len,
+            res.len()
+        )));
+    }
     match info.tensor_type {
         TensorType::F32 => {
-            let (r_mean, r_std, g_mean, g_std, b_mean, b_std) = get_rgb_mean_std_from_info!(info);
-            let bytes = img.as_bytes();
-            debug_assert_eq!(res.len(), bytes.len() * std::mem::size_of::<f32>());
-
-            let hw = (img.width() * img.height()) as usize;
-            return match data_layout {
-                ImageDataLayout::NHWC => {
-                    let mut i = 0;
-                    while i < bytes.len() {
-                        let f = ((bytes[i] as f32) - r_mean) / r_std;
-                        res[res_index..res_index + 4].copy_from_slice(&f.to_ne_bytes());
-                        res_index += 4;
-                        let f = ((bytes[i + 1] as f32) - g_mean) / g_std;
-                        res[res_index..res_index + 4].copy_from_slice(&f.to_ne_bytes());
-                        res_index += 4;
-                        let f = ((bytes[i + 2] as f32) - b_mean) / b_std;
-                        res[res_index..res_index + 4].copy_from_slice(&f.to_ne_bytes());
-                        res_index += 4;
-                        i += 3;
-                    }
-                    Ok(())
-                }
-                ImageDataLayout::NCHW | ImageDataLayout::CHWN => {
-                    for start in 0..3 {
-                        let mut i = start as usize;
-                        while i < hw {
-                            let f = ((bytes[i] as f32) - r_mean) / r_std;
-                            res[res_index..res_index + 4].copy_from_slice(&f.to_ne_bytes());
-                            res_index += 4;
-                            i += 3;
-                        }
-                    }
-                    Ok(())
-                }
+            let (means, stds) = rgb_mean_std(info)?;
+            let mut out = res.chunks_exact_mut(std::mem::size_of::<f32>());
+            let mut put = |value: u8, c: usize| {
+                let f = (value as f32 - means[c]) / stds[c];
+                out.next().unwrap().copy_from_slice(&f.to_ne_bytes());
             };
-        }
-        TensorType::U8 => {
-            let bytes = img.as_bytes();
-            debug_assert_eq!(res.len(), bytes.len());
-            return match data_layout {
+            match data_layout {
                 ImageDataLayout::NHWC => {
-                    // just copy
-                    res.copy_from_slice(bytes);
-                    Ok(())
+                    for px in bytes.chunks_exact(3) {
+                        put(px[0], 0);
+                        put(px[1], 1);
+                        put(px[2], 2);
+                    }
                 }
                 // batch is always 1 now
                 ImageDataLayout::NCHW | ImageDataLayout::CHWN => {
-                    let hw = (img.width() * img.height()) as usize;
                     for c in 0..3 {
-                        let mut i = c as usize;
-                        while i < hw {
-                            res[res_index] = bytes[i];
-                            res_index += 1;
-                            i += c;
+                        for p in 0..hw {
+                            put(bytes[p * 3 + c], c);
                         }
                     }
-                    Ok(())
                 }
-            };
+            }
+            Ok(())
+        }
+        TensorType::U8 => {
+            match data_layout {
+                ImageDataLayout::NHWC => res[..bytes.len()].copy_from_slice(bytes),
+                // batch is always 1 now
+                ImageDataLayout::NCHW | ImageDataLayout::CHWN => {
+                    let mut out = res.iter_mut();
+                    for c in 0..3 {
+                        for p in 0..hw {
+                            *out.next().unwrap() = bytes[p * 3 + c];
+                        }
+                    }
+                }
+            }
+            Ok(())
         }
         _ => unimplemented!(),
     }
@@ -273,5 +263,91 @@ mod ops_inner {
                 destination.put_pixel(x, y, pixel);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn info(
+        layout: ImageDataLayout,
+        tensor_type: TensorType,
+        mean: Vec<f32>,
+        std: Vec<f32>,
+    ) -> ImageToTensorInfo {
+        ImageToTensorInfo {
+            image_data_layout: layout,
+            color_space: ImageColorSpaceType::RGB,
+            tensor_type,
+            tensor_shape: ImageLikeTensorShape {
+                batch: 1,
+                width: 2,
+                height: 1,
+                channels: 3,
+            },
+            stats_min: vec![],
+            stats_max: vec![],
+            normalization_options: (mean, std),
+        }
+    }
+
+    fn to_f32(buf: &[u8]) -> Vec<f32> {
+        buf.chunks_exact(4)
+            .map(|b| f32::from_ne_bytes(b.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn test_rgb8_to_f32_per_channel_normalization() {
+        let img = RgbImage::from_raw(2, 1, vec![10, 20, 30, 40, 50, 60]).unwrap();
+        let mut buf = vec![0u8; 6 * 4];
+
+        let nhwc = info(
+            ImageDataLayout::NHWC,
+            TensorType::F32,
+            vec![0., 1., 2.],
+            vec![1., 2., 4.],
+        );
+        rgb8_image_buffer_to_tensor(&img, &nhwc, &mut buf).unwrap();
+        assert_eq!(to_f32(&buf), [10., 9.5, 7., 40., 24.5, 14.5]);
+
+        let nchw = info(
+            ImageDataLayout::NCHW,
+            TensorType::F32,
+            vec![0., 1., 2.],
+            vec![1., 2., 4.],
+        );
+        rgb8_image_buffer_to_tensor(&img, &nchw, &mut buf).unwrap();
+        assert_eq!(to_f32(&buf), [10., 40., 9.5, 24.5, 7., 14.5]);
+
+        let single = info(ImageDataLayout::NHWC, TensorType::F32, vec![10.], vec![10.]);
+        rgb8_image_buffer_to_tensor(&img, &single, &mut buf).unwrap();
+        assert_eq!(to_f32(&buf), [0., 1., 2., 3., 4., 5.]);
+    }
+
+    #[test]
+    fn test_rgb8_to_f32_requires_normalization_options() {
+        let img = RgbImage::from_raw(2, 1, vec![0; 6]).unwrap();
+        let mut buf = vec![0u8; 6 * 4];
+        let missing = info(ImageDataLayout::NHWC, TensorType::F32, vec![], vec![]);
+        assert!(rgb8_image_buffer_to_tensor(&img, &missing, &mut buf).is_err());
+        let mut short = vec![0u8; 6 * 4 - 1];
+        let ok = info(ImageDataLayout::NHWC, TensorType::F32, vec![0.], vec![1.]);
+        assert!(rgb8_image_buffer_to_tensor(&img, &ok, &mut short).is_err());
+    }
+
+    #[test]
+    fn test_rgb8_to_u8_layouts() {
+        let img = RgbImage::from_raw(2, 1, vec![10, 20, 30, 40, 50, 60]).unwrap();
+        let mut buf = vec![0u8; 6];
+
+        let nhwc = info(ImageDataLayout::NHWC, TensorType::U8, vec![], vec![]);
+        rgb8_image_buffer_to_tensor(&img, &nhwc, &mut buf).unwrap();
+        assert_eq!(buf, [10, 20, 30, 40, 50, 60]);
+
+        let nchw = info(ImageDataLayout::NCHW, TensorType::U8, vec![], vec![]);
+        rgb8_image_buffer_to_tensor(&img, &nchw, &mut buf).unwrap();
+        assert_eq!(buf, [10, 40, 20, 50, 30, 60]);
     }
 }

--- a/src/preprocess/vision/image.rs
+++ b/src/preprocess/vision/image.rs
@@ -126,17 +126,28 @@ pub(super) fn rgb8_image_buffer_to_tensor<'t, Container>(
 where
     Container: std::ops::Deref<Target = [u8]>,
 {
-    debug_assert!(
-        img.width() == info.width()
-            && img.height() == info.height()
-            && info.color_space != ImageColorSpaceType::GRAYSCALE
-    );
+    let shape = &info.tensor_shape;
+    if shape.batch != 1
+        || shape.channels != 3
+        || img.width() != info.width()
+        || img.height() != info.height()
+    {
+        return Err(Error::ModelInconsistentError(format!(
+            "Expect a `1x{}x{}x3` RGB image tensor, but got batch `{}`, `{}x{}`, channels `{}`",
+            img.height(),
+            img.width(),
+            shape.batch,
+            shape.height,
+            shape.width,
+            shape.channels
+        )));
+    }
 
     let data_layout = info.image_data_layout;
     let res = output_buffer.as_mut();
     let bytes = img.as_bytes();
     let hw = (img.width() * img.height()) as usize;
-    let expected_len = bytes.len() * tensor_byte_size!(info.tensor_type);
+    let expected_len = shape.elem_size() * tensor_byte_size!(info.tensor_type);
     if res.len() < expected_len {
         return Err(Error::ArgumentError(format!(
             "Expect output buffer at least `{}` bytes, but got `{}`",
@@ -276,15 +287,25 @@ mod test {
         mean: Vec<f32>,
         std: Vec<f32>,
     ) -> ImageToTensorInfo {
+        info_with_shape(layout, tensor_type, mean, std, (1, 2, 1, 3))
+    }
+
+    fn info_with_shape(
+        layout: ImageDataLayout,
+        tensor_type: TensorType,
+        mean: Vec<f32>,
+        std: Vec<f32>,
+        (batch, width, height, channels): (usize, usize, usize, usize),
+    ) -> ImageToTensorInfo {
         ImageToTensorInfo {
             image_data_layout: layout,
             color_space: ImageColorSpaceType::RGB,
             tensor_type,
             tensor_shape: ImageLikeTensorShape {
-                batch: 1,
-                width: 2,
-                height: 1,
-                channels: 3,
+                batch,
+                width,
+                height,
+                channels,
             },
             stats_min: vec![],
             stats_max: vec![],
@@ -335,6 +356,26 @@ mod test {
         let mut short = vec![0u8; 6 * 4 - 1];
         let ok = info(ImageDataLayout::NHWC, TensorType::F32, vec![0.], vec![1.]);
         assert!(rgb8_image_buffer_to_tensor(&img, &ok, &mut short).is_err());
+    }
+
+    #[test]
+    fn test_rgb8_rejects_unsupported_tensor_shapes() {
+        let img = RgbImage::from_raw(2, 1, vec![0; 6]).unwrap();
+        let mut buf = vec![0u8; 2 * 6 * 4];
+        for shape in [(2, 2, 1, 3), (1, 2, 1, 1), (1, 2, 1, 4), (1, 1, 2, 3)] {
+            let info = info_with_shape(
+                ImageDataLayout::NHWC,
+                TensorType::F32,
+                vec![0.],
+                vec![1.],
+                shape,
+            );
+            assert!(
+                rgb8_image_buffer_to_tensor(&img, &info, &mut buf).is_err(),
+                "{:?}",
+                shape
+            );
+        }
     }
 
     #[test]

--- a/src/tasks/common/options/classification_options.rs
+++ b/src/tasks/common/options/classification_options.rs
@@ -92,7 +92,7 @@ macro_rules! classification_options_check {
             ));
         }
         if !$self.$field_name.category_allow_list.is_empty()
-            && !$self.classification_options.category_deny_list.is_empty()
+            && !$self.$field_name.category_deny_list.is_empty()
         {
             return Err(crate::Error::ArgumentError(
                 "Cannot use both `category_allow_list` and `category_deny_list`".into(),


### PR DESCRIPTION
## Summary

- `Category`: `PartialEq` compared index while `Ord` compared score and unwrapped `partial_cmp` (panic on NaN); order by score with `total_cmp`, tie-break by index
- `Landmarks::into_iter` was `todo!()`; `Landmark` equality dropped `abs()` on y/z and implemented `Eq` for a tolerance comparison
- remove the results iterator `collect()` stub that always panicked
- image to tensor: blue channel used the green mean/std, missing `NormalizationOptions` panicked, NCHW/CHWN paths iterated with the wrong stride
- audio: channel-mismatch checks were inverted, so mono models skipped the downmix and multi-channel models rejected matching input
- detection location buffer was sized `num_boxes * num_boxes` instead of `num_boxes * num_coords`
- quantized embeddings were narrowed to `i8` before clamping
- `classification_options_check!` validated the deny list of the hardcoded field instead of `$field_name`
- zip end of central directory record minimum size is 22 bytes, not 20

## Why

Behavior bugs found while auditing the crate for Rust anti-patterns. Each commit fixes one bug and adds a regression test where the code runs without WASI-NN.

## Validation

- `cargo test --lib --release`: 18 unit tests pass under wasmedge (10 new)
- `cargo check --all-targets` with default features and each of `vision`, `audio`, `text`
