### PR TITLE
ci: use the Azure apt mirror and skip recommended packages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@main
 
+      - name: use the Azure apt mirror
+        run: sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+
       - name: install curl and rust
         run: ./scripts/rust-init.sh
 

--- a/scripts/download-testdata.sh
+++ b/scripts/download-testdata.sh
@@ -45,7 +45,7 @@ install_ffmpeg() {
   if which ffmpeg; then
     echo "FFMpeg is installed."
   else
-    apt install ffmpeg -y
+    apt install -y --no-install-recommends ffmpeg
   fi
 }
 

--- a/scripts/ffmpeg-deps-init.sh
+++ b/scripts/ffmpeg-deps-init.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # install libclang and clang
-apt install -y libclang1-14 clang
+apt install -y --no-install-recommends libclang1-14 clang
 
 FFMPEG_VERSION="v0.0.1"
 FFMPEG_FILENAME="ffmpeg-6.0-wasm32-wasi-v0.0.1.tar.gz"


### PR DESCRIPTION
## Summary

- the job runs in an `ubuntu:22.04` container whose apt sources point at `archive.ubuntu.com`; point it at `azure.archive.ubuntu.com`, the mirror the runner image itself uses
- `apt install ffmpeg` and `apt install clang` skip recommended packages (VA/VDPAU drivers, mesa, `llvm-14-dev`, …): 157 → 114 MB and 174 → 88 MB. `clang` stays because it registers the `cc` alternative rustc uses to link host build scripts

## Why

`archive.ubuntu.com` dropped to 20–50 kB/s from the runners on 2026-09-11: the two apt steps took 56 and 107 minutes (run 34587575239) instead of 3 and 2 while the test step stayed at 5–7 minutes, with no workflow or script change.

## Validation

- replayed the workflow steps in an amd64 `ubuntu:22.04` container: apt at 2–18 MB/s from the Azure mirror, `ffmpeg` generates `bird_burger_tabby.mp4`, `cargo build --release --tests --features ffmpeg` and the `audio,ffmpeg` / `vision,ffmpeg` test binaries build (bindgen + link)
- CI on this PR
